### PR TITLE
Added support for luajit

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "galleryBanner": {
         "color": "#050523",
         "theme": "dark"
-    }, 
+    },
     "engines": {
         "vscode": "^1.0.0"
     },
@@ -34,6 +34,11 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Show warning message if there is an error when saving a file"
+                },
+                "lualinter.interpreter": {
+                    "type": "string",
+                    "default": "luac",
+                    "description": "Choose between luac and luajit interpreters"
                 }
             }
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,14 +4,13 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import {spawn, ChildProcess} from 'child_process';
 
-const LUAC_OUTPUT_REGEXP = /.+: .+:([0-9]+): (.+) near.*[<'](.*)['>]/;
-const LUAC_COMMAND = 'luac';
+const OUTPUT_REGEXP = /.+: .+:([0-9]+): (.+) near.*[<'](.*)['>]/;
 
 let diagnosticCollection: vscode.DiagnosticCollection;
 let currentDiagnostic: vscode.Diagnostic;
 
 function parseDocumentDiagnostics(document: vscode.TextDocument, luacOutput: string) {
-    const matches = LUAC_OUTPUT_REGEXP.exec(luacOutput);
+    const matches = OUTPUT_REGEXP.exec(luacOutput);
     if (!matches) {
         return;
     }
@@ -37,7 +36,7 @@ function parseDocumentDiagnostics(document: vscode.TextDocument, luacOutput: str
         }
     }
     var range = new vscode.Range(rangeStart, rangeEnd);
-    currentDiagnostic = new vscode.Diagnostic(range, message.text, vscode.DiagnosticSeverity.Error); 
+    currentDiagnostic = new vscode.Diagnostic(range, message.text, vscode.DiagnosticSeverity.Error);
 }
 
 function lintDocument(document: vscode.TextDocument, warnOnError: Boolean = false) {
@@ -54,26 +53,40 @@ function lintDocument(document: vscode.TextDocument, warnOnError: Boolean = fals
     const options = {
         cwd: path.dirname(document.fileName)
     };
-    var luacProcess: ChildProcess = spawn(LUAC_COMMAND, ['-p', '-'], options);
-    luacProcess.stdout.setEncoding('utf8');
-    luacProcess.stderr.on('data', (data: Buffer) => {
+
+    // Determine the interpreter to use
+    let interpreter = lualintrConfic.interpreter;
+    if ((interpreter !== "luac") && (interpreter !== "luajit")) {
+        interpreter = "luac";
+    }
+
+    let cmd;
+    if (interpreter === "luac") {
+        cmd = "-p";
+    } else {
+        cmd = "-bl";
+    }
+
+    var luaProcess: ChildProcess = spawn(interpreter, [cmd, '-'], options);
+    luaProcess.stdout.setEncoding('utf8');
+    luaProcess.stderr.on('data', (data: Buffer) => {
         if (data.length == 0) {
             return;
         }
         parseDocumentDiagnostics(document, data.toString());
     });
-    luacProcess.stderr.on('error', error => {
-        vscode.window.showErrorMessage('luac error: ' + error);
+    luaProcess.stderr.on('error', error => {
+        vscode.window.showErrorMessage(interpreter + ' error: ' + error);
     });
-    // Pass current file contents to luac's stdin
-    luacProcess.stdin.end(new Buffer(document.getText()));
-    luacProcess.on('exit', (code: number, signal: string) => {
+    // Pass current file contents to lua's stdin
+    luaProcess.stdin.end(new Buffer(document.getText()));
+    luaProcess.on('exit', (code: number, signal: string) => {
         if (!currentDiagnostic) {
             diagnosticCollection.clear();
         } else {
             diagnosticCollection.set(document.uri, [currentDiagnostic]);
 
-            // Optionally show warining message 
+            // Optionally show warining message
             if (warnOnError && lualinterConfig.get('warnOnSave')) {
                 vscode.window.showWarningMessage(`Current file contains an error: "${currentDiagnostic.message}" at line ${currentDiagnostic.range.start.line}`);
             }


### PR DESCRIPTION
I was unable to verify if this actually works, I can't quite figure out how to get my dev extension to load in VS Code, so I would highly recommend giving this a test before accepting the PR.

This PR, assuming it works, does the following:
- Added another option in the workspace settings that defaults to the luac interpreter
- Added a check in the code to determine which interpreter to use, and which flag to use (`luac -p` or `luajit -bl`)
- Removed all references to "luac" in code
- Defaults to luac interpreter if an invalid interpreter is set
